### PR TITLE
feat: connect analysis flow to backend

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { DashboardHeader } from "@/components/DashboardHeader";
 import { AnalysisForm, type AnalysisFormData } from "@/components/AnalysisForm";
 import { ProgressSection } from "@/components/ProgressSection";
@@ -15,8 +15,9 @@ const Index = () => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [resultsData, setResultsData] = useState<OneToOneResult[]>([]);
   const [currentAnalysisType, setCurrentAnalysisType] = useState<string>('graph');
+  const wsRef = useRef<WebSocket | null>(null);
 
-  const addLog = useCallback((message: string, type: LogEntry['type'], data?: any) => {
+  const addLog = useCallback((message: string, type: LogEntry['type'], data?: unknown) => {
     const newLog: LogEntry = {
       id: `${Date.now()}-${Math.random()}`,
       timestamp: new Date(),
@@ -32,127 +33,115 @@ const Index = () => {
     setResultsData([]);
   }, []);
 
-  // Simulate WebSocket functionality for demo
-  const simulateAnalysis = useCallback(async (formData: AnalysisFormData) => {
-    const mockJobId = `job_${Date.now()}`;
-    setJobId(mockJobId);
+  const startAnalysis = useCallback(async (formData: AnalysisFormData) => {
     setStatus('processing');
     setProgress(0);
     setConnectionStatus('connecting');
     setCurrentAnalysisType(formData.analysisType);
-    
     addLog(`Sending request for <strong>${formData.analysisType}</strong>...`, 'info');
-    
-    // Simulate connection
-    setTimeout(() => {
-      setConnectionStatus('connected');
-      addLog(`Job started with ID: <strong>${mockJobId}</strong>. WebSocket connection established.`, 'processing');
-    }, 500);
 
-    // Simulate progress updates
-    const progressSteps = [10, 25, 40, 60, 75, 85, 95, 100];
-    
-    // Different data structures based on analysis type
-    const oneToOneChunks: OneToOneResult[] = [
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "3กล9186",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 4323,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_เข้า", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
-      },
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "3ขด9516",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 5001,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_ออก", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
-      },
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "3ฒย3481",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 4933,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_เข้า", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
-      },
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "5กถ8983",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 1465,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_เข้า", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
-      },
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "5ขฎ894",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 1388,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_เข้า", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
-      },
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "653734",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 3599,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_เข้า", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
-      },
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "704603",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 2674,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_เข้า", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
-      },
-      {
-        target_vehicle: "กม6671",
-        other_vehicle: "704814",
-        actual_common_cameras: 3,
-        actual_max_time_diff_sec: 4979,
-        common_camera_names: ["4_มห_หนองเอี่ยน_เข้า", "4_มค_ประชาอุทิศ_เข้า", "4_มห_โนนยางพระไกรศรีสุข_เข้า"]
+    try {
+      const response = await fetch('http://api.ailprnsb.com/api/realtimeprocress/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to start analysis');
       }
-    ];
 
-    const chunks = formData.analysisType === 'one_to_one' ? oneToOneChunks : [];
-    const chunkSize = formData.analysisType === 'one_to_one' ? 2 : 1;
+      const data = await response.json();
+      const newJobId = data.jobId || data.job_id || data.id;
+      setJobId(newJobId);
+      addLog(`Job started with ID: <strong>${newJobId}</strong>`, 'processing');
 
-    for (let i = 0; i < progressSteps.length; i++) {
-      await new Promise(resolve => setTimeout(resolve, 800));
-      
-      const currentProgress = progressSteps[i];
-      setProgress(currentProgress);
-      
-      if (formData.analysisType === 'one_to_one' && i < 4) { // Simulate 4 chunk updates
-        const startIdx = i * chunkSize;
-        const endIdx = Math.min(startIdx + chunkSize, chunks.length);
-        const currentChunks = chunks.slice(startIdx, endIdx);
-        
-        setResultsData(prev => [...prev, ...currentChunks]);
-        addLog(`Received chunk. Total results so far: <strong>${(i + 1) * chunkSize}</strong>`, 'data_chunk');
-      } else if (currentProgress === 100) {
-        setStatus('complete');
-        if (formData.analysisType === 'one_to_one') {
-          addLog('1-to-1 analysis finished.', 'complete');
-          addLog(`<strong>Final Aggregated Results (${chunks.length} items):</strong>`, 'complete');
-        } else {
-          addLog('Analysis complete!', 'complete');
+      wsRef.current?.close();
+      const ws = new WebSocket(`ws://api.ailprnsb.com/api/realtimeprocress/ws/${newJobId}`);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        setConnectionStatus('connected');
+        addLog('WebSocket connection established.', 'processing');
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data);
+
+          if (msg.progress !== undefined) {
+            setProgress(msg.progress);
+            addLog(`Processing progress: ${msg.progress}%`, 'processing');
+          }
+
+          if (Array.isArray(msg.results) && msg.results.length > 0) {
+            setResultsData(prev => {
+              const updated = [...prev, ...msg.results];
+              addLog(`Received chunk. Total results so far: <strong>${updated.length}</strong>`, 'data_chunk');
+              return updated;
+            });
+          }
+
+          if (msg.status === 'complete') {
+            setStatus('complete');
+            addLog('Analysis complete!', 'complete');
+            setConnectionStatus('disconnected');
+            ws.close();
+            toast({
+              title: 'การวิเคราะห์เสร็จสิ้น',
+              description: `พบผลลัพธ์ทั้งหมด ${msg.total ?? ''} รายการ`
+            });
+          } else if (msg.status === 'failed') {
+            setStatus('failed');
+            addLog(`Error: ${msg.error || 'Unknown error'}`, 'failed');
+            setConnectionStatus('disconnected');
+            ws.close();
+            toast({
+              title: 'เกิดข้อผิดพลาด',
+              description: msg.error || 'ไม่สามารถเริ่มการวิเคราะห์ได้ กรุณาลองใหม่อีกครั้ง',
+              variant: 'destructive'
+            });
+          }
+        } catch (e) {
+          addLog('Received non-JSON message', 'info');
         }
+      };
+
+      ws.onerror = () => {
+        setStatus('failed');
         setConnectionStatus('disconnected');
+        addLog('WebSocket error', 'failed');
         toast({
-          title: "การวิเคราะห์เสร็จสิ้น",
-          description: `พบผลลัพธ์ทั้งหมด ${chunks.length} รายการ`,
+          title: 'เกิดข้อผิดพลาดของ WebSocket',
+          description: 'ไม่สามารถเชื่อมต่อกับ WebSocket ได้',
+          variant: 'destructive'
         });
-      } else {
-        addLog(`Processing progress: ${currentProgress}%`, 'processing');
-      }
+        ws.close();
+      };
+
+      ws.onclose = () => {
+        setConnectionStatus('disconnected');
+      };
+    } catch (error) {
+      setStatus('failed');
+      setConnectionStatus('disconnected');
+      addLog(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`, 'failed');
+      throw error;
     }
   }, [addLog]);
+
+  useEffect(() => {
+    return () => {
+      wsRef.current?.close();
+    };
+  }, []);
 
   const handleFormSubmit = useCallback(async (formData: AnalysisFormData) => {
     setIsProcessing(true);
     clearLogs();
-    
+
     try {
-      await simulateAnalysis(formData);
+      await startAnalysis(formData);
     } catch (error) {
       setStatus('failed');
       addLog(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`, 'failed');
@@ -164,7 +153,7 @@ const Index = () => {
     } finally {
       setIsProcessing(false);
     }
-  }, [simulateAnalysis, addLog, clearLogs]);
+  }, [startAnalysis, addLog, clearLogs]);
 
   return (
     <div className="min-h-screen bg-background">


### PR DESCRIPTION
## Summary
- replace demo analyzer with real API call and realtime WebSocket updates
- handle WebSocket errors and surface failure toast notifications

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npx eslint src/pages/Index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68909035d7cc83219449086170908d67